### PR TITLE
Fixes #15: Increased size of usernames inside of messages

### DIFF
--- a/app/Components/MessageList.js
+++ b/app/Components/MessageList.js
@@ -55,7 +55,7 @@ function Message({
 
       <div className="flex gap-2 items-center">
         <span
-          className={`font-bold sma:text-sm underline ${
+          className={`font-bold sma:text-sm md:text-base underline ${
             rightAlign === true ? "text-blue-700" : "text-stone-1000"
           } ${sameAsBefore ? "hidden" : ""}`}
         >


### PR DESCRIPTION
This change increases the size of usernames inside of chat messages, ensuring that usernames stand out more clearly from the surrounding text. This can be beneficial because it allows users to more easily identify who is speaking, enhancing the overall chat experience. 